### PR TITLE
Set aiohttp to >=3.7.4,<4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     license="MIT",
     url="https://github.com/timmo001/system-bridge-connector-py",
     packages=find_packages(exclude=["tests", "generator"]),
-    install_requires=["aiohttp>=3.7.3", "websockets>=9.0.2"],
+    install_requires=["aiohttp>=3.7.4,<4", "websockets>=9.0.2"],
 )


### PR DESCRIPTION
# Proposed Changes

Set aiohttp to >=3.7.4,<4

## Related Issues

Avoid CVE-2021-21330

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
