### PR TITLE
Set websockets to > 9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     license="MIT",
     url="https://github.com/timmo001/system-bridge-connector-py",
     packages=find_packages(exclude=["tests", "generator"]),
-    install_requires=["aiohttp>=3.7.3", "websockets>=9.0.2"],
+    install_requires=["aiohttp>=3.7.3", "websockets>=9.1,<10"],
 )


### PR DESCRIPTION
# Proposed Changes

Set websockets to > 9.1

## Related Issues

Version 9.1 fixes a security issue introduced in version 8.0 of websockets.

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
