### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/systembridge/client/__init__.py
+++ b/systembridge/client/__init__.py
@@ -29,7 +29,7 @@ class BridgeClient(BridgeBase):
 
     async def request(self, method: str, url: str, **kwargs) -> ClientResponse:
         """Make a request."""
-        async with async_timeout.timeout(20, loop=get_event_loop()):
+        async with async_timeout.timeout(20):
             response: ClientResponse = await self._session.request(
                 method,
                 url,


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed
